### PR TITLE
Increase COMMLOST_TIMEOUT in pcnet.c

### DIFF
--- a/apcupsd/Dockerfile
+++ b/apcupsd/Dockerfile
@@ -1,8 +1,22 @@
+FROM alpine AS apcupsd
+
+RUN apk add \
+    alpine-conf \
+    alpine-sdk \
+    sudo
+
+RUN git clone --depth 1 https://gitlab.alpinelinux.org/alpine/aports.git
+
+RUN --mount=target=/aports/main/apcuspd,source=./apcupsd \
+    abuild-keygen -a -i -n \
+    && abuild -Fr -C /aports/main/apcupsd -P /packages
+
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Install requirements
-RUN apk add --no-cache apcupsd
+RUN --mount=target=/mnt,source=/packages,from=apcupsd \
+    apk add --allow-untrusted --no-cache /mnt/main/*/apcupsd-3.14.14*.apk
 
 # /dev/log is symlinked to /run/systemd/journal/dev-log by the container host;
 # the parent path must exist for syslogd to create the log socket at startup.

--- a/apcupsd/apcupsd/APKBUILD
+++ b/apcupsd/apcupsd/APKBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+pkgname=apcupsd
+pkgver=3.14.14
+pkgrel=7
+pkgdesc="A Daemon to control APC UPSes"
+subpackages="$pkgname-doc $pkgname-webif $pkgname-openrc"
+url="http://www.apcupsd.org"
+arch="all"
+license="GPL-2.0-or-later"
+depends="util-linux"
+makedepends="
+	gd-dev
+	libusb-compat-dev
+	linux-headers
+	mandoc
+	net-snmp-dev
+	"
+options="!check" # no test suite included
+source="https://sourceforge.net/projects/apcupsd/files/apcupsd%20-%20Stable/$pkgver/apcupsd-$pkgver.tar.gz
+	apcupsd.initd
+	apcupsd.powerfail.initd
+	apcupsd-alpine.patch
+	manify-with-mandoc.patch
+	pcnet-commlost-timeout.patch
+	"
+
+prepare() {
+	update_config_sub
+	default_prepare
+}
+
+build() {
+	export CHARSET="ISO8859-1"
+	export LANG="C"
+
+	ac_cv_path_SHUTDOWN="/sbin/poweroff" \
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		--enable-modbus-usb \
+		--enable-usb \
+		--enable-snmp \
+		--enable-cgi
+	make
+}
+
+package() {
+	make DESTDIR=$pkgdir install
+	install -D -m755 "$srcdir"/apcupsd.initd "$pkgdir"/etc/init.d/apcupsd
+	install -D -m755 "$srcdir"/apcupsd.powerfail.initd \
+		"$pkgdir"/etc/init.d/apcupsd.powerfail
+}
+
+webif() {
+	mkdir -p "$subpkgdir"/usr/share/webapps/apcupsd
+	mv "$pkgdir"/etc/apcupsd/*.cgi "$subpkgdir"/usr/share/webapps/apcupsd
+}
+
+sha512sums="c953bbf3e08f809748a7978a3952604176390d1cd276f187fe096d9bc3c8993b52127e8350c0363387da41318e24b4d1e00ea58df71f3bb8f50c9a5a64cd2d7f  apcupsd-3.14.14.tar.gz
+82bff9001e86e2eb082e0bdebce69563458bb9e864f6f70622aa7d173d5134522f295b7f2496a9ef74aa6075e52026f714810c49a866026ee834acb8adbb3c70  apcupsd.initd
+8d1c266bd86cd1cdf4fccdd171a877957bf5e26e1bb8c20e4c9c6b362a63d8cc1b887a1661939e4e56228a8d23dfc81fe782806b5d1527423c2ef7872cbeb881  apcupsd.powerfail.initd
+4f0712519213c4ef14f41eeef681c5498fac7bf42f205de8a855938f8e834d9488d86820d7c883e89d0d305ee287e17e2d321dbbc98ae12f8487bf58aa0d4a6b  apcupsd-alpine.patch
+151d6c2f2a150a9ffbf411042e8f5df883c79b2ac15292e009edc58338d790917b1afd01dc588c08741be70cc6de6bb1b13b4ddd233e5907efaebb7c5c33e311  manify-with-mandoc.patch
+9c85f1fc5def7cab68a1c003c732f4e56e501a75584466de9e64237bb7baebb75fcbbe9d0210742d5664a1909b3d58a2ab55e11e9d96607c83bdc0d648f4f31b  pcnet-commlost-timeout.patch"

--- a/apcupsd/apcupsd/apcupsd-alpine.patch
+++ b/apcupsd/apcupsd/apcupsd-alpine.patch
@@ -1,0 +1,40 @@
+--- ./platforms/apccontrol.in.orig	2014-03-22 16:55:26.000000000 +0000
++++ ./platforms/apccontrol.in	2014-05-01 08:35:12.652406970 +0000
+@@ -20,10 +20,19 @@
+ 
+ APCPID=@PIDDIR@/apcupsd.pid
+ APCUPSD=@sbindir@/apcupsd
+-SHUTDOWN=@SHUTDOWN@
++POWEROFF=/sbin/poweroff
++REBOOT=/sbin/reboot
+ SCRIPTSHELL=@SCRIPTSHELL@
+ SCRIPTDIR=@sysconfdir@
+-WALL=wall
++WALL=_wall
++
++_wall() {
++   local i
++   local msg=$(cat)
++   for i in /dev/pts/*; do
++       [ -c "$i" ] && echo "$msg" > $i
++   done
++}
+ 
+ export SYSADMIN=root
+ export APCUPSD_MAIL="@APCUPSD_MAIL@"
+@@ -104,11 +113,13 @@
+     ;;
+     doreboot)
+ 	echo "UPS ${2} initiating Reboot Sequence" | ${WALL}
+-	${SHUTDOWN} -r now "apcupsd UPS ${2} initiated reboot"
++	echo "apcupsd UPS ${2} initiated reboot" | ${WALL}
++	$REBOOT
+     ;;
+     doshutdown)
+ 	echo "UPS ${2} initiated Shutdown Sequence" | ${WALL}
+-	${SHUTDOWN} -h now "apcupsd UPS ${2} initiated shutdown"
++	echo "apcupsd UPS ${2} initiated shutdown" | ${WALL}
++	$POWEROFF
+     ;;
+     annoyme)
+ 	echo "Power problems with UPS ${2}. Please logoff." | ${WALL}

--- a/apcupsd/apcupsd/apcupsd.initd
+++ b/apcupsd/apcupsd/apcupsd.initd
@@ -1,0 +1,39 @@
+#!/sbin/openrc-run
+# Copyright 2007 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/sys-power/apcupsd/files/apcupsd.init.2,v 1.1 2009/01/15 15:21:11 flameeyes Exp $
+
+INSTANCE="${SVCNAME#*.}"
+if [ -z "${INSTANCE}" ] || [ "${SVCNAME}" = "apcupsd" ]; then
+	INSTANCE="apcupsd"
+fi
+
+depend() {
+	use net
+	after firewall
+}
+
+start() {
+	rm -f /etc/apcupsd/powerfail
+	rm -f /etc/nologin
+
+	export SERVICE="${SVCNAME}"
+
+	ebegin "Starting APC UPS daemon"
+	start-stop-daemon \
+		--start --pidfile "/var/run/${SVCNAME}.pid" \
+		--exec /sbin/apcupsd -- \
+		-f "/etc/apcupsd/${INSTANCE}.conf" \
+		-P "/var/run/${SVCNAME}.pid"
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping APC UPS daemon"
+	start-stop-daemon \
+		--stop --pidfile "/var/run/${SVCNAME}.pid" \
+            	--retry TERM/5/TERM/5 \
+		--exec /sbin/apcupsd
+	eend $?
+}
+

--- a/apcupsd/apcupsd/apcupsd.powerfail.initd
+++ b/apcupsd/apcupsd/apcupsd.powerfail.initd
@@ -1,0 +1,17 @@
+#!/sbin/openrc-run
+# Copyright 2009 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description='Signal the UPS to kill power in a power failure condition'
+
+depend() {
+	need mount-ro
+}
+
+start() {
+	if [ "$RC_RUNLEVEL" = "shutdown" -a -f /etc/apcupsd/powerfail ] ; then
+		ebegin 'Signaling UPS to kill power'
+		/sbin/apcupsd --killpower
+		eend $?
+	fi
+}

--- a/apcupsd/apcupsd/manify-with-mandoc.patch
+++ b/apcupsd/apcupsd/manify-with-mandoc.patch
@@ -1,0 +1,15 @@
+cmd:col is no longer provided by util-linux-misc
+since 2.40, it was disabled for musl libc in
+https://github.com/util-linux/util-linux/commit/8886d84e25a457702b45194d69a47313f76dc6bc
+
+--- a/autoconf/targets.mak
++++ b/autoconf/targets.mak
+@@ -298,7 +298,7 @@
+ # Format a manpage into plain text
+ define MANIFY
+ 	@$(ECHO) "  MAN  " $(1) -\> $(2)
+-	$(V)man ./$(1) | col -b > $(2)
++	$(V)mandoc -Tascii ./$(1) > $(2)
+ endef
+ 
+ # Rule to build a Windows resource object from the source RC file

--- a/apcupsd/apcupsd/pcnet-commlost-timeout.patch
+++ b/apcupsd/apcupsd/pcnet-commlost-timeout.patch
@@ -1,0 +1,15 @@
+--- ./src/drivers/pcnet/pcnet.c	(revision 2381)
++++ ./src/drivers/pcnet/pcnet.c	(working copy)
+@@ -32,10 +32,10 @@
+ 
+ /*
+  * Number of seconds with no data before we declare COMMLOST.
+- * UPS should report in every 25 seconds. We allow 2 missing
++ * UPS should report in every 25 seconds. We allow 3 missing
+  * reports plus a fudge factor.
+  */
+-#define COMMLOST_TIMEOUT   55
++#define COMMLOST_TIMEOUT   80
+ 
+ /* Win32 needs a special close for sockets */
+ #ifdef HAVE_MINGW


### PR DESCRIPTION
This PR updates the pcnet driver to increase COMMLOST_TIMEOUT to prevent spurious timeouts. See https://sourceforge.net/p/apcupsd/mailman/message/59114143/ for details.
